### PR TITLE
fix(fetchInject,injectors): Allow optional Content-Type header parameter

### DIFF
--- a/src/fetch-inject.js
+++ b/src/fetch-inject.js
@@ -32,7 +32,7 @@ const fetchInject = function (inputs, promise) {
   return Promise.all(deferreds).then(() => {
     resources.forEach(resource => {
       thenables.push({ then: resolve => {
-        resource.blob.type.split(';')[0] === 'text/css'
+        resource.blob.type.split(';')[0].trim() === 'text/css'
           ? injectHead(window, document, 'style', resource, resolve)
           : injectHead(window, document, 'script', resource, resolve)
       }})

--- a/src/fetch-inject.js
+++ b/src/fetch-inject.js
@@ -32,7 +32,7 @@ const fetchInject = function (inputs, promise) {
   return Promise.all(deferreds).then(() => {
     resources.forEach(resource => {
       thenables.push({ then: resolve => {
-        resource.blob.type === 'text/css'
+        resource.blob.type.split(';')[0] === 'text/css'
           ? injectHead(window, document, 'style', resource, resolve)
           : injectHead(window, document, 'script', resource, resolve)
       }})

--- a/src/injectors.js
+++ b/src/injectors.js
@@ -1,1 +1,1 @@
-export const head = (function(i,s,o,g,r,a,m){a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.type=g.blob.type;a.appendChild(s.createTextNode(g.text));a.onload=r(g);m?m.parentNode.insertBefore(a,m):s.head.appendChild(a)}) // eslint-disable-line
+export const head = (function(i,s,o,g,r,a,m){a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.type=g.blob.type.split(';')[0];a.appendChild(s.createTextNode(g.text));a.onload=r(g);m?m.parentNode.insertBefore(a,m):s.head.appendChild(a)}) // eslint-disable-line

--- a/src/injectors.js
+++ b/src/injectors.js
@@ -1,1 +1,1 @@
-export const head = (function(i,s,o,g,r,a,m){a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.type=g.blob.type.split(';')[0];a.appendChild(s.createTextNode(g.text));a.onload=r(g);m?m.parentNode.insertBefore(a,m):s.head.appendChild(a)}) // eslint-disable-line
+export const head = (function(i,s,o,g,r,a,m){a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.type=g.blob.type.split(';')[0].trim();a.appendChild(s.createTextNode(g.text));a.onload=r(g);m?m.parentNode.insertBefore(a,m):s.head.appendChild(a)}) // eslint-disable-line


### PR DESCRIPTION
HTTP servers may return for example the HTTP header "Content-Type: text/css; charset=utf-8" for CSS files. These files end up as script elemenets and will never be executed. Accordingly the data field of the header has to be split after the first semicolon. Also, Microsoft Edge won't execute css/js with optional header parameters, therefore injectors.js has to be fixed the same way.